### PR TITLE
WV-3567: Add fix for multiversion and drupal 8.8.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
+    "cweagans/composer-patches": "~1.0",
     "drunomics/contentpool_data_model": "^1.1.2",
     "drunomics/contentpool_replication": "^2.0",
     "drunomics/service-utils": "*",
@@ -39,6 +40,13 @@
     "drupal/coder": "^8.2",
     "woohoolabs/yang": "^1.2",
     "php-http/guzzle6-adapter": "^2.0"
+  },
+  "extra": {
+    "patches": {
+      "drupal/multiversion": {
+        "#3090566: Make Multiversion compatible with the latest changes related to url aliases in Drupal 8.8.x": "https://www.drupal.org/files/issues/2020-01-20/3090566-15.patch"
+      }
+    }
   },
   "repositories": [
     {


### PR DESCRIPTION
Adds a multiversion patch that is needed for drupal 8.8.